### PR TITLE
fix: gracefully handle closed IO stream leading to SIGPIPE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,9 @@ fn main() -> Result<()> {
             }
 
             if !args.quiet {
-                stdout.write_all(&line)?;
+                if stdout.write_all(&line).is_err() {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
This would otherwise lead to panic when the streams are early closed,
for example by piped grep or head/tail calls.