### PR TITLE
Don't error if anewer file doesn't exist yet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
             let content = fs::read(&filename)
                 .with_context(|| anyhow!("Failed to open file: {:?}", filename))?;
 
-            has_newline = !content.is_empty() && content[content.len() - 1] == b'\n';
+            has_newline = content.is_empty() || content[content.len() - 1] == b'\n';
 
             let mut remaining = &content[..];
             loop {


### PR DESCRIPTION
Resolves #5

Also fixes a bug with empty anewer files:
```
# Before
% rm foo.txt; touch foo.txt; echo x | cargo run foo.txt; cat foo.txt
x

x
# After
% rm foo.txt; touch foo.txt; echo x | cargo run foo.txt; cat foo.txt
x
x
%
```